### PR TITLE
Actually call sync connection close method()

### DIFF
--- a/django_async_redis/cache.py
+++ b/django_async_redis/cache.py
@@ -72,7 +72,7 @@ class RedisCache(BaseCache):
 
     def close(self, **kwargs):
         # TODO Remove this once Django's close_caches implement cache.close_async
-        async_to_sync(self.close_async)
+        async_to_sync(self.close_async)()
 
     @property
     def client(self) -> Union[DefaultClient]:


### PR DESCRIPTION
## Description

Without an extra pair of parentheses, this was just creating the sync wrapper of the method.

## Rationale

...